### PR TITLE
feat(missing): Find `package.json` from ancestors

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "homepage": "https://github.com/bahmutov/npm-quick-run#readme",
   "dependencies": {
+    "findup": "0.1.5",
     "npm-utils": "0.6.1",
     "simple-bin-help": "1.3.0"
   },

--- a/src/quick-run.js
+++ b/src/quick-run.js
@@ -1,7 +1,7 @@
 const findScripts = require('./find-scripts')
 const runNpmCommand = require('npm-utils').test
 const join = require('path').join
-const exists = require('fs').existsSync
+const findup = require('findup')
 
 function printAllScripts (pkg) {
   console.error('Available scripts are', Object.keys(pkg.scripts).join(', '))
@@ -29,12 +29,13 @@ const npmErrorLoggers = {
 }
 
 function runPrefix (prefix) {
-  const fullPath = join(process.cwd(), 'package.json')
-  if (!exists(fullPath)) {
-    console.error('Cannot find package.json in the current folder')
+  try {
+    var fullPath = findup.sync(process.cwd(), 'package.json')
+  } catch (e) {
+    console.error('Cannot find package.json in the current folder and its ancestors')
     process.exit(-1)
   }
-  const pkg = require(fullPath)
+  const pkg = require(join(fullPath, 'package.json'))
   if (!pkg.scripts) {
     console.error('Cannot find any scripts in the current package')
     process.exit(-1)


### PR DESCRIPTION
Previous version requires `package.json` existed in current directory.
But sometimes we run npm scripts in sub- or descendant directory.

This commits allows to find `package.json` from its ancestor directory
using findup package.
