### PR TITLE
fix(package): Add README to docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "files": [
     "bin",
     "src/*.js",
-    "!src/*-spec.js"
+    "!src/*-spec.js",
+    "README.md"
   ],
   "preferGlobal": true,
   "repository": {


### PR DESCRIPTION
The README is missing on the package: https://www.npmjs.com/package/npm-quick-run