### PR TITLE
chore(package.json): Drop in cross-spawn package

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "homepage": "https://github.com/bahmutov/npm-quick-run#readme",
   "dependencies": {
     "bluebird": "3.3.1",
-    "cross-spawn-async": "2.1.8",
+    "cross-spawn": "4.0.0",
     "debug": "2.2.0",
     "findup": "0.1.5",
     "json-package": "1.1.2",

--- a/src/run.js
+++ b/src/run.js
@@ -1,4 +1,4 @@
-var spawn = require('cross-spawn-async')
+var spawn = require('cross-spawn')
 var Promise = require('bluebird')
 
 function runner (app, parts) {


### PR DESCRIPTION
since https://github.com/IndigoUnited/node-cross-spawn-async#cross-spawn-async is deprecated.

I also wanted to get the `child_process`es to preserve coloured output, but I couldn't get that to work with what I found regarding preserving raw output.

Thoughts, @bahmutov? 