### PR TITLE
feat: support stop dot at the end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           # use prefix search by word
           node bin/npm-quick-run.js t-f 'foo bar'
           node bin/npm-quick-run.js t:f 'foo bar'
+          # with stopper . at the end
+          # https://github.com/bahmutov/npm-quick-run/issues/35
+          node bin/npm-quick-run.js t-f. 'foo bar'
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
           # with stopper . at the end
           # https://github.com/bahmutov/npm-quick-run/issues/35
           node bin/npm-quick-run.js t-f. 'foo bar'
+          # should find single "size" script
+          node bin/npm-quick-run.js s.
 
       - name: Semantic Release 🚀
         uses: cycjimmy/semantic-release-action@v2

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Install as a global tool `npm install -g npm-quick-run`. This creates two aliase
     $ nr t      # runs script starting with "t"
     $ nr m -w   # runs a script starting with "m", probably "npm run mocha -- -w"
     $ nr -i     # runs npm-quick-run in interactive mode
+    $ nr c-r    # find script that has two+ words
+                # first starts with "c", second with "r"
+    $ nr c-r.   # find script with exactly two words
+                # first starts with "c", second with "r"
 
 ## Demo
 
@@ -80,6 +84,34 @@ nr c-r
 # returns both "cypress:run" and "cypress:run:record"
 nr c-r-r
 # executes "cypress:run:record"
+```
+
+### Separate words with count
+
+Sometimes you want to match a script with one word, but there are multiple two and three word scripts matching the prefix.
+
+```json
+{
+  "scripts": {
+    "cypress": "cypress -help",
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run",
+    "cypress:run:record": "cypress run --record"
+  }
+}
+```
+
+In order to run "cypress" script use prefix with "." at the end:
+
+```
+# same as "npm run cypress"
+$ nr c. # only finds single word starting with "c"
+
+# same as "npm run cypress:open"
+$ nr c-o.
+
+# same as "npm run cypress:run"
+$ nr c-r.
 ```
 
 ## Extra arguments

--- a/package-lock.json
+++ b/package-lock.json
@@ -3645,9 +3645,9 @@
       "dev": true
     },
     "json-package": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/json-package/-/json-package-1.2.2.tgz",
-      "integrity": "sha512-db8LZmjN6hVdTlmZHP9Rfuxp8kF/IG96bD3p+W2ohGrvLxCQE3wjCkuvZQCzcxaqL6YaMOvelSQUGLUHeoXBww==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-package/-/json-package-1.3.0.tgz",
+      "integrity": "sha512-WwMqPt0bTsbZESYfDR4E30jZwa00wqT90oUUaHwz4E+EBRBOmzNOXASDSRrw5W8GSkVS4JUWIfUvMNiHzQUZ0w==",
       "requires": {
         "check-more-types": "2.24.0",
         "findup": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "fuzzy": "0.1.3",
     "inquirer": "3.0.5",
     "inquirer-autocomplete-prompt": "0.8.0",
-    "json-package": "1.2.2",
+    "json-package": "1.3.0",
     "simple-bin-help": "1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- closes #35

Sometimes you want to match a script with one word, but there are multiple two and three word scripts matching the prefix.

```json
{
  "scripts": {
    "cypress": "cypress -help",
    "cypress:open": "cypress open",
    "cypress:run": "cypress run",
    "cypress:run:record": "cypress run --record"
  }
}
```

In order to run "cypress" script use prefix with "." at the end:

```
# same as "npm run cypress"
$ nr c. # only finds single word starting with "c"

# same as "npm run cypress:open"
$ nr c-o.

# same as "npm run cypress:run"
$ nr c-r.
```