### PR TITLE
feat: add support for Yarn

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4184,6 +4184,12 @@
         }
       }
     },
+    "mock-fs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.0.0.tgz",
+      "integrity": "sha512-A5mm/SpSDwwc/klSaEvvKMGQQtiGiQy8UcDAd/vpVO1fV+4zaHjt39yKgCSErFzv2zYxZIUx9Ud/7ybeHBf8Fg==",
+      "dev": true
+    },
     "modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "execa-wrap": "1.2.1",
     "git-issues": "1.3.1",
     "mocha": "4.0.1",
+    "mock-fs": "5.0.0",
     "semantic-release": "^17.4.1",
     "snap-shot-it": "4.0.1",
     "standard": "16.0.3"

--- a/src/quick-run-spec.js
+++ b/src/quick-run-spec.js
@@ -1,7 +1,39 @@
+const mockFS = require('mock-fs')
+const execaWrap = require('execa-wrap')
+const snapshot = require('snap-shot-it')
+
 /* global describe, it */
 describe('quick run', () => {
   const quickRun = require('./quick-run')
   it('is a function', () => {
     console.assert(typeof quickRun === 'function')
+  })
+
+  it('runs npm when package-lock.json is present', () => {
+    return new Promise(resolve => {
+      mockFS({
+        'package-lock.json': {}
+      })
+      resolve()
+    }).then(() => {
+      let pm = quickRun.getPackageManager()
+      console.assert(pm === 'npm')
+    }).finally(() => {
+      mockFS.restore()
+    })
+  })
+
+  it('runs yarn when yarn.lock is present', () => {
+    return new Promise(resolve => {
+      mockFS({
+        'yarn.lock': {}
+      })
+      resolve()
+    }).then(() => {
+      let pm = quickRun.getPackageManager()
+      console.assert(pm === 'yarn')
+    }).finally(() => {
+      mockFS.restore()
+    })
   })
 })

--- a/src/quick-run.js
+++ b/src/quick-run.js
@@ -126,7 +126,7 @@ function runScript (prefix, pkg) {
   const packageManager = getPackageManager()
   const extraArguments = packageManager === 'npm'
     ? ['run', candidates[0], '--'].concat(process.argv.slice(3))
-    : [candidates[0]].concat(process.argv.slice(3))
+    : ['run', candidates[0]].concat(process.argv.slice(3))
 
   debug('formed command: %s %o', packageManager, extraArguments)
 


### PR DESCRIPTION
These changes check the current package manager before executing a script. If `yarn.lock` is present, we run `yarn run ...`; otherwise, we fall back to NPM.